### PR TITLE
Toggle bootstrap hidden class

### DIFF
--- a/dynamicforms/static/dynamicforms/dynamicforms.js
+++ b/dynamicforms/static/dynamicforms/dynamicforms.js
@@ -1022,6 +1022,18 @@ dynamicforms = {
     var $hideParent = $hide.parents('[data-hide-with-field]');
     if ($hideParent.length > 0)
       $hide = $hideParent;
+
+    // Toggle bootstrap hidden class
+    let hidden_class = "d-none";
+    if (this.DYNAMICFORMS.bootstrap_version == "v3")
+      hidden_class = 'hidden';
+
+    if (visible) {
+      $hide.toggleClass(hidden_class, false);
+    } else {
+      $hide.toggleClass(hidden_class, true);
+    }
+
     $hide.toggle(visible);
   },
 

--- a/dynamicforms/static/dynamicforms/dynamicforms.js
+++ b/dynamicforms/static/dynamicforms/dynamicforms.js
@@ -1024,7 +1024,7 @@ dynamicforms = {
       $hide = $hideParent;
 
     // Toggle bootstrap hidden class
-    let hidden_class = "d-none";
+    var hidden_class = "d-none";
     if (this.DYNAMICFORMS.bootstrap_version == "v3")
       hidden_class = 'hidden';
 


### PR DESCRIPTION
Currently $hide.toggle doesn't work since it doesn't actually toggle bootstrap hidden or d-none class.

Updated function to toggle correct class for bootstrap version. 