### PR TITLE
Update @dynamicforms/vue-forms, @dynamicforms/vuetify-inputs and vue-cached-icon

### DIFF
--- a/dynamicforms/__init__.py
+++ b/dynamicforms/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "DynamicForms"
-__version__ = "0.81.8"
+__version__ = "0.81.9"
 __author__ = "Jure Erznožnik"
 __email__ = "jure.erznoznik@gmail.com"
 __license__ = "BSD 3-Clause"

--- a/package-lock.json
+++ b/package-lock.json
@@ -581,16 +581,30 @@
         }
       }
     },
+    "node_modules/@dynamicforms/translatable": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@dynamicforms/translatable/-/translatable-0.1.0.tgz",
+      "integrity": "sha512-F0zDonOD3bS3guOVTNsVIggBk16R+L1P/T8bYLIyGG0Gspyc1nPffnd1C+paKzxeinPWZhH/9+N0e9qRF6Va1Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.2"
+      }
+    },
     "node_modules/@dynamicforms/vue-forms": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@dynamicforms/vue-forms/-/vue-forms-0.17.1.tgz",
-      "integrity": "sha512-Schwb4nAIu8SFBCsDOM5/2kYgg6fqBjAyUjUYGD0GEiH4vh6ES9RF0N8beEmHANmKQ2XiFxWyWIZUiWaPR/EXg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dynamicforms/vue-forms/-/vue-forms-1.0.0.tgz",
+      "integrity": "sha512-FAyeFlU7LtcbvB9zfOnecrhPwKFylz1l5B9frztDTbIHnUQxhKfQvubQsPEfJ4jXcn7P4Pi5JYyDGCIhrqjCWg==",
       "license": "MIT",
       "peer": true,
       "workspaces": [
         "docs"
       ],
       "dependencies": {
+        "@dynamicforms/translatable": "^0.1.0",
         "lodash-es": "^4.17.21"
       },
       "engines": {
@@ -601,9 +615,9 @@
       }
     },
     "node_modules/@dynamicforms/vuetify-inputs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@dynamicforms/vuetify-inputs/-/vuetify-inputs-0.10.0.tgz",
-      "integrity": "sha512-cZyu/Tedfdr01jXQ14XEzodMnMfPNLRWISUAPf82rc05Po1sss42xuOj+zeVfTLvNvXVMRLMcURjtwmbbm3UDA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@dynamicforms/vuetify-inputs/-/vuetify-inputs-0.11.0.tgz",
+      "integrity": "sha512-Z8oRx9RHGT0sd9fDyQmOwqYIiaINlVKqOTefAvHTDUvfosMHykjRzAYB8xhxBj5sruF9OcqAJQAyWEcOKijpww==",
       "license": "MIT",
       "workspaces": [
         "docs"
@@ -612,7 +626,8 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dynamicforms/vue-forms": "^0.17.0",
+        "@dynamicforms/translatable": "^0.1.0",
+        "@dynamicforms/vue-forms": "^1.0.0",
         "@mdi/font": "^7.4.47",
         "@tiptap/core": "^3.30.2",
         "@tiptap/extension-image": "^3.30.2",
@@ -12128,9 +12143,9 @@
       }
     },
     "node_modules/vue-cached-icon": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/vue-cached-icon/-/vue-cached-icon-3.0.3.tgz",
-      "integrity": "sha512-qfeNxwulU7jTbzLVCA4geLM5E3Y2ThpjR8+qukosFoX+9nGOLrrO8/nx3UznxWsvXKRmdOFVMKQa6ftvPLFetQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vue-cached-icon/-/vue-cached-icon-3.1.1.tgz",
+      "integrity": "sha512-y5Ct3xIzBxjV1A68kuyov/1OfJWaEmShT47EgQbqctsJj2JuMAP+Pk665d1hNv06tlqe6Yjt5KjEezmLWN7WRQ==",
       "license": "BSD-3-Clause",
       "workspaces": [
         "demo"
@@ -12718,7 +12733,7 @@
     "vue/demo": {
       "version": "1.0.0",
       "dependencies": {
-        "@dynamicforms/vuetify-inputs": "^0.10.0",
+        "@dynamicforms/vuetify-inputs": "^0.11.0",
         "@fullcalendar/core": "^6.1.4",
         "@fullcalendar/daygrid": "^6.1.4",
         "@fullcalendar/interaction": "^6.1.4",
@@ -12734,7 +12749,7 @@
         "lodash-es": "^4.17.12",
         "suncalc": "^1.9.0",
         "vue": "^3",
-        "vue-cached-icon": "^3.0.3",
+        "vue-cached-icon": "^3.1.1",
         "vue-router": "^4",
         "vuetify": "^3"
       },
@@ -13281,14 +13296,14 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dynamicforms/vue-forms": "^0.17.1",
-        "@dynamicforms/vuetify-inputs": "^0.10.0",
+        "@dynamicforms/vue-forms": "^1.0.0",
+        "@dynamicforms/vuetify-inputs": "^0.11.0",
         "@kyvg/vue3-notification": "^3.2.1",
         "axios": "^1.4.0",
         "date-fns": "^4.1.0",
         "lodash-es": "^4.17.12",
         "vue": "^3.5.2",
-        "vue-cached-icon": "^3.0.3",
+        "vue-cached-icon": "^3.1.1",
         "vue-router": "^4.1.6",
         "vuetify": "^3.12.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamicform-project",
-  "version": "0.81.8",
+  "version": "0.81.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamicform-project",
-      "version": "0.81.8",
+      "version": "0.81.9",
       "license": "UNLICENSED",
       "workspaces": [
         "vue/*"
@@ -13269,7 +13269,7 @@
     },
     "vue/dynamicforms": {
       "name": "@velis/dynamicforms",
-      "version": "0.81.8",
+      "version": "0.81.9",
       "license": "Proprietary",
       "dependencies": {
         "resize-observer-polyfill": "^1.5.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynamicform-project",
   "private": false,
-  "version": "0.81.8",
+  "version": "0.81.9",
   "description": "Data entry boilerplate components and a RESTful API consumer",
   "author": "velis74",
   "license": "UNLICENSED",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dynamicforms"
-version = "0.81.8"
+version = "0.81.9"
 description = "DyF performs all the visualisation & data entry of your DRF Serializers & ViewSets and adds some candy of its own"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/vue/demo/package.json
+++ b/vue/demo/package.json
@@ -7,7 +7,7 @@
     "preview": "vite --mode preview"
   },
   "dependencies": {
-    "@dynamicforms/vuetify-inputs": "^0.10.0",
+    "@dynamicforms/vuetify-inputs": "^0.11.0",
     "@fullcalendar/core": "^6.1.4",
     "@fullcalendar/daygrid": "^6.1.4",
     "@fullcalendar/interaction": "^6.1.4",
@@ -23,7 +23,7 @@
     "lodash-es": "^4.17.12",
     "suncalc": "^1.9.0",
     "vue": "^3",
-    "vue-cached-icon": "^3.0.3",
+    "vue-cached-icon": "^3.1.1",
     "vue-router": "^4",
     "vuetify": "^3"
   },

--- a/vue/dynamicforms/package.json
+++ b/vue/dynamicforms/package.json
@@ -40,14 +40,14 @@
     "node": ">=22"
   },
   "peerDependencies": {
-    "@dynamicforms/vue-forms": "^0.17.1",
-    "@dynamicforms/vuetify-inputs": "^0.10.0",
+    "@dynamicforms/vue-forms": "^1.0.0",
+    "@dynamicforms/vuetify-inputs": "^0.11.0",
     "@kyvg/vue3-notification": "^3.2.1",
     "axios": "^1.4.0",
     "date-fns": "^4.1.0",
     "lodash-es": "^4.17.12",
     "vue": "^3.5.2",
-    "vue-cached-icon": "^3.0.3",
+    "vue-cached-icon": "^3.1.1",
     "vue-router": "^4.1.6",
     "vuetify": "^3.12.3"
   },

--- a/vue/dynamicforms/package.json
+++ b/vue/dynamicforms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@velis/dynamicforms",
   "private": false,
-  "version": "0.81.8",
+  "version": "0.81.9",
   "type": "module",
   "description": "Data entry boilerplate components and a RESTful API consumer",
   "author": "Jure Erznožnik",


### PR DESCRIPTION
## Summary
- `@dynamicforms/vue-forms` `^0.17.1` → `^1.0.0` (0.18.0 adds translatable validator messages via `@dynamicforms/translatable`; 1.0.0 freezes that API with no further changes)
- `@dynamicforms/vuetify-inputs` `^0.10.0` → `^0.11.0` (reactive `TranslatableStrings` backed by `@dynamicforms/translatable`, updated RTF editor toolbar styling)
- `vue-cached-icon` `^3.0.3` → `^3.1.1`

None of these packages' breaking changes (translation callback signature, `@dynamicforms/translatable` peer dep) touch this repo's code — `translateStrings`/`TranslatableStrings` aren't used here, so this is a version bump only.

## Test plan
- [x] `npm run build -w @velis/dynamicforms`
- [x] `npm run test -w @velis/dynamicforms` (149 tests passing)
- [x] `vite build` for the demo app